### PR TITLE
fix: apply ParseIntPipe for parameter

### DIFF
--- a/src/modules/author/author.controller.spec.ts
+++ b/src/modules/author/author.controller.spec.ts
@@ -48,7 +48,7 @@ describe('author controller', () => {
     expect(res2[0].termsAccepted).toBe(false);
     expect(res2[0].books).toHaveLength(2);
 
-    const res3 = await authorController.update('' + id, { name: 'a2' });
+    const res3 = await authorController.update(id, { name: 'a2' });
     expect(res3.id).toBeDefined();
     expect(res3.name).toBe('a2');
     expect(res3.email).toBe('e1');

--- a/src/modules/author/author.controller.ts
+++ b/src/modules/author/author.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpException, HttpStatus, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, HttpStatus, Param, ParseIntPipe, Post, Put } from '@nestjs/common';
 import { EntityRepository, QueryOrder, wrap } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Author } from '../../entities';
@@ -18,8 +18,8 @@ export class AuthorController {
   }
 
   @Get(':id')
-  async findOne(@Param() id: string) {
-    return await this.authorRepository.findOneOrFail(+id, {
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return await this.authorRepository.findOneOrFail(id, {
       populate: ['books'],
     });
   }
@@ -37,8 +37,8 @@ export class AuthorController {
   }
 
   @Put(':id')
-  async update(@Param() id: string, @Body() body: any) {
-    const author = await this.authorRepository.findOneOrFail(+id);
+  async update(@Param('id', ParseIntPipe) id: number, @Body() body: any) {
+    const author = await this.authorRepository.findOneOrFail(id);
     wrap(author).assign(body);
     await this.authorRepository.persist(author);
 

--- a/src/modules/book/book.controller.spec.ts
+++ b/src/modules/book/book.controller.spec.ts
@@ -48,7 +48,7 @@ describe('author controller', () => {
     expect(res2[0].author.email).toBe('e1');
     expect(res2[0].author.termsAccepted).toBe(false);
 
-    const res3 = await bookController.update('' + id, { title: 'b2' });
+    const res3 = await bookController.update(id, { title: 'b2' });
     expect(res3.id).toBeDefined();
     expect(res3.title).toBe('b2');
     expect(res3.author).toBeDefined();

--- a/src/modules/book/book.controller.ts
+++ b/src/modules/book/book.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpException, HttpStatus, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, HttpStatus, Param, ParseIntPipe, Post, Put } from '@nestjs/common';
 import { EntityRepository, QueryOrder, wrap } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Book } from '../../entities';
@@ -18,8 +18,8 @@ export class BookController {
   }
 
   @Get(':id')
-  async findOne(@Param() id: string) {
-    return await this.bookRepository.findOneOrFail(+id, {
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return await this.bookRepository.findOneOrFail(id, {
       populate: ['author'],
     });
   }
@@ -38,8 +38,8 @@ export class BookController {
   }
 
   @Put(':id')
-  async update(@Param() id: string, @Body() body: any) {
-    const book = await this.bookRepository.findOne(+id);
+  async update(@Param('id', ParseIntPipe) id: number, @Body() body: any) {
+    const book = await this.bookRepository.findOne(id);
 
     if (!book) {
       throw new HttpException('Book not found', HttpStatus.NOT_FOUND);


### PR DESCRIPTION
Hello,

When I call `findOne` for Get / Update, it gives error below.
```
Error: You cannot call 'EntityManager.findOne()' with empty 'where' parameter
    at EntityValidator.validateEmptyWhere (/nestjs-example-app/node_modules/@mikro-orm/core/entity/EntityValidator.js:87:19)
    at SqlEntityManager.findOne (/nestjs-example-app/node_modules/@mikro-orm/core/EntityManager.js:262:24)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async SqlEntityManager.findOneOrFail (/nestjs-example-app/node_modules/@mikro-orm/core/EntityManager.js:305:24)
```

Here's the snippet of author.controller.ts
```
  @Get(':id')
  async findOne(@Param() id: string) {
    return await this.authorRepository.findOneOrFail(+id, {
      populate: ['books'],
    });
  }
```
This is because Nest's route handler parameter decorator extract all params as object. e.g. when I call `/author/1`, id equals to `{ id: '1' }` not 1. For that,  `+id` gives `NaN` and that is not what I want.

I suggest extracting single parameter like `findOne(@Param('id') id: string)` and  using ParseIntPipe, which Nest offers to transform the input param to Integer. 😎
( https://docs.nestjs.com/pipes )